### PR TITLE
Add --stripCountry import flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Then you can run the following commands:
 * `npm run export` creates a POT file with the extracted translations in `./locales/template.pot`
 * `npm run import` creates a json file containing your all your translations in `./src/translations.json`
 
+Running `npm run import --stripCountry` will strip the country code in the resulting file, ie. the key `da_DK` will become `da`.
+
 ## CI
 
 To get output for CI, add the following script:

--- a/bin/import.js
+++ b/bin/import.js
@@ -9,18 +9,28 @@ const prettyPrint = true
 
 let translations = {}
 
+const arg = process.argv[2]
+
+let stripCountry = false
+
+if (arg === '--stripCountry') {
+  stripCountry = true
+}
+
 glob(localesPath, (err, files) => {
   if (err) {
     throw err
   }
 
-  files.map(file => {
+  files.forEach((file) => {
     const pocontent = po2json.parseFileSync(file)
     const header = pocontent['']
     if (!header) {
       throw new Error('import: missing header')
     }
-    const lang = header['Language']
+
+    const langHeader = header['Language']
+    const lang = stripCountry ? langHeader.slice(0, 2) : langHeader
     if (!lang) {
       throw new Error('import: language missing from header')
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@connectedcars/react-i18n",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@connectedcars/react-i18n",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "@connectedcars/po2json": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@connectedcars/react-i18n",
   "author": "Connected Cars <oss@connectedcars.io>",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Translations!",
   "license": "MIT",
   "homepage": "https://github.com/connectedcars/react-i18n#readme",


### PR DESCRIPTION
Running `npm run import --stripCountry` will strip the country code in the resulting file, ie. the key `da_DK` will become `da`.