### PR TITLE
feat: [sc-103865] Allow defining a custom pattern for react-i18n string matcher

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -92,7 +92,11 @@ class I18nProvider extends PureComponent<I18nProviderProps, I18nProviderState> {
       this.props.options
     )
 
-    return replaceString(msg, this.genData(data))
+    return replaceString(
+      msg,
+      this.genData(data),
+      this.props.options.replaceStringRegex
+    )
   }
 
   tx: TranslateJsxFunc = (message, data, context) => {
@@ -123,7 +127,11 @@ class I18nProvider extends PureComponent<I18nProviderProps, I18nProviderState> {
       this.props.options
     )
 
-    return replaceString(message, this.genData(data, count))
+    return replaceString(
+      message,
+      this.genData(data, count),
+      this.props.options.replaceStringRegex
+    )
   }
 
   tnx: TranslatePluralJsxFunc = (count, singular, plural, data, context) => {

--- a/src/translate/__snapshots__/replace-content.test.tsx.snap
+++ b/src/translate/__snapshots__/replace-content.test.tsx.snap
@@ -24,3 +24,5 @@ exports[`replace-content can replace JSX 3`] = `
 `;
 
 exports[`replace-content can replace a string 1`] = `"Hello John Doe"`;
+
+exports[`replace-content can replace a string with a custom pattern 1`] = `"Hello John Doe"`;

--- a/src/translate/__snapshots__/replace-content.test.tsx.snap
+++ b/src/translate/__snapshots__/replace-content.test.tsx.snap
@@ -26,3 +26,5 @@ exports[`replace-content can replace JSX 3`] = `
 exports[`replace-content can replace a string 1`] = `"Hello John Doe"`;
 
 exports[`replace-content can replace a string with a custom pattern 1`] = `"Hello John Doe"`;
+
+exports[`replace-content can replace a string with a custom pattern 2`] = `"Hello John Doe"`;

--- a/src/translate/replace-content.test.tsx
+++ b/src/translate/replace-content.test.tsx
@@ -18,6 +18,14 @@ describe('replace-content', () => {
         { pattern: (key) => `{{{${key}}}}` }
       )
     ).toMatchSnapshot()
+
+    expect(
+      replaceString(
+        'Hello {{{firstName} {lastName}',
+        { firstName: 'John', lastName: 'Doe' },
+        { pattern: (key) => `{?{?{${key}}}?}?` }
+      )
+    ).toMatchSnapshot()
   })
 
   it('can replace JSX', () => {

--- a/src/translate/replace-content.test.tsx
+++ b/src/translate/replace-content.test.tsx
@@ -10,6 +10,16 @@ describe('replace-content', () => {
     ).toMatchSnapshot()
   })
 
+  it('can replace a string with a custom pattern', () => {
+    expect(
+      replaceString(
+        'Hello {{{name}}}',
+        { name: 'John Doe' },
+        { pattern: (key) => `{{{${key}}}}` }
+      )
+    ).toMatchSnapshot()
+  })
+
   it('can replace JSX', () => {
     expect(
       replaceJsx('Hello <strong>{name}</strong>', { name: 'John Doe' }, false)

--- a/src/translate/replace-content.tsx
+++ b/src/translate/replace-content.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
 
 import { DocNode, ElementNode, parse, TextNode } from '../parser'
-import { TranslateDataWithJSX } from '../types'
+import { ReplaceStringRegex, TranslateDataWithJSX } from '../types'
 
 export const replaceString = (
   text: string,
-  data?: TranslateDataWithJSX | null
+  data?: TranslateDataWithJSX | null,
+  options: ReplaceStringRegex = {
+    pattern: (key) => `{${key}}`,
+    flags: 'g',
+  }
 ) => {
   if (!data) {
     return text
@@ -16,7 +20,10 @@ export const replaceString = (
     if (typeof v === 'function') {
       return
     }
-    text = text.replace(new RegExp(`{${key}}`, 'g'), String(v))
+    text = text.replace(
+      new RegExp(options.pattern(key), options.flags ?? 'g'),
+      String(v)
+    )
   })
 
   return text

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface TranslationOptions {
   strict?: boolean
   verbose?: boolean
   jsxWhitelist?: TranslateDataWithJSX
+  replaceStringRegex?: ReplaceStringRegex
 
   content?: {
     trimWhiteSpace?: boolean
@@ -65,3 +66,8 @@ export type TranslatePluralJsxFunc = (
 ) => ReactNode
 
 export type FormatLocaleOption = 'xx-yy' | 'xx_yy' | 'xx-YY' | 'xx_YY'
+
+export interface ReplaceStringRegex {
+  pattern: (key: string) => string
+  flags?: string
+}


### PR DESCRIPTION
Story details: https://app.shortcut.com/connectedcars/story/103865

This PR introduces the ability to define a custom pattern for replacing strings in translations.