### PR TITLE
Add arg to set language header in import script

### DIFF
--- a/bin/import.js
+++ b/bin/import.js
@@ -9,12 +9,14 @@ const prettyPrint = true
 
 let translations = {}
 
-const arg = process.argv[2]
+const args = process.argv.splice(2)
 
-let stripCountry = false
+const stripCountry = args.includes('--stripCountry')
 
-if (arg === '--stripCountry') {
-  stripCountry = true
+const languageHeaderIndex = args.findIndex((v) => v === '--languageHeader')
+let languageHeader = 'Language'
+if (languageHeaderIndex !== -1) {
+  languageHeader = args[languageHeaderIndex + 1]
 }
 
 glob(localesPath, (err, files) => {
@@ -29,7 +31,7 @@ glob(localesPath, (err, files) => {
       throw new Error('import: missing header')
     }
 
-    const langHeader = header['Language']
+    const langHeader = header[languageHeader]
     const lang = stripCountry ? langHeader.slice(0, 2) : langHeader
     if (!lang) {
       throw new Error('import: language missing from header')

--- a/bin/import.js
+++ b/bin/import.js
@@ -9,7 +9,7 @@ const prettyPrint = true
 
 let translations = {}
 
-const args = process.argv.splice(2)
+const args = process.argv.slice(2)
 
 const stripCountry = args.includes('--stripCountry')
 


### PR DESCRIPTION
This is useful if you for example use Crowdin and want to overwrite the default `Language` header we pull out from the PO file with, for example, `X-Crowdin-Language` instead.