### PR TITLE
Add `defaultLocale` support for better language fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ const translations = {
 const store = new I18nStore({
   translations,
   locale: 'da',
+  defaultLocale: 'en',
 })
 
 class ExampleA extends React.Component {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -82,29 +82,31 @@ class I18nProvider extends PureComponent<I18nProviderProps, I18nProviderState> {
   }
 
   t: TranslateFunc = (message, data, context) => {
-    const msg = getTranslation(
-      this.state.storeState.translations,
-      this.state.storeState.locale,
-      null,
-      message,
-      null,
+    const msg = getTranslation({
+      translations: this.state.storeState.translations,
+      locale: this.state.storeState.locale,
+      defaultLocale: this.state.storeState.defaultLocale,
+      n: null,
+      singular: message,
+      plural: null,
       context,
-      this.props.options
-    )
+      options: this.props.options,
+    })
 
     return replaceString(msg, this.genData(data), this.props.options)
   }
 
   tx: TranslateJsxFunc = (message, data, context) => {
-    const msg = getTranslation(
-      this.state.storeState.translations,
-      this.state.storeState.locale,
-      null,
-      message,
-      null,
+    const msg = getTranslation({
+      translations: this.state.storeState.translations,
+      locale: this.state.storeState.locale,
+      defaultLocale: this.state.storeState.defaultLocale,
+      n: null,
+      singular: message,
+      plural: null,
       context,
-      this.props.options
-    )
+      options: this.props.options,
+    })
 
     return replaceJsx(msg, this.genData(data), this.props.options).map(
       (el, idx) => <React.Fragment key={idx}>{el}</React.Fragment>
@@ -112,29 +114,31 @@ class I18nProvider extends PureComponent<I18nProviderProps, I18nProviderState> {
   }
 
   tn: TranslatePluralFunc = (count, singular, plural, data, context) => {
-    const message = getTranslation(
-      this.state.storeState.translations,
-      this.state.storeState.locale,
-      count,
+    const message = getTranslation({
+      translations: this.state.storeState.translations,
+      locale: this.state.storeState.locale,
+      defaultLocale: this.state.storeState.defaultLocale,
+      n: count,
       singular,
       plural,
       context,
-      this.props.options
-    )
+      options: this.props.options,
+    })
 
     return replaceString(message, this.genData(data, count), this.props.options)
   }
 
   tnx: TranslatePluralJsxFunc = (count, singular, plural, data, context) => {
-    const message = getTranslation(
-      this.state.storeState.translations,
-      this.state.storeState.locale,
-      count,
+    const message = getTranslation({
+      translations: this.state.storeState.translations,
+      locale: this.state.storeState.locale,
+      defaultLocale: this.state.storeState.defaultLocale,
+      n: count,
       singular,
       plural,
       context,
-      this.props.options
-    )
+      options: this.props.options,
+    })
 
     return replaceJsx(
       message,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { Translations } from './types'
 
 export interface I18nStoreState {
   locale: string
+  defaultLocale: string
   translations: Translations
 }
 
@@ -11,11 +12,13 @@ class I18nStore {
   private listeners: I18nStoreCallback[]
   private translations: Translations
   private locale: string
+  private defaultLocale: string
 
-  constructor({ translations, locale }: I18nStoreState) {
+  constructor({ translations, locale, defaultLocale }: I18nStoreState) {
     this.listeners = []
     this.translations = translations
     this.locale = locale
+    this.defaultLocale = defaultLocale
   }
 
   setLocale = (locale: string) => {
@@ -42,6 +45,7 @@ class I18nStore {
     return {
       translations: this.translations,
       locale: this.locale,
+      defaultLocale: this.defaultLocale,
     }
   }
 

--- a/src/translate/translate.test.tsx
+++ b/src/translate/translate.test.tsx
@@ -40,62 +40,137 @@ const translationDataLowercase: Translations = {
   },
 }
 
-const opts: TranslationOptions = { defaultLocale: 'en' }
+const defaultLocale = 'en'
+const options: TranslationOptions = {}
 
 describe('translate', () => {
   describe('translates from translations set', () => {
     it('translate a singular string', () => {
       expect(
-        getTranslation(translationData, 'da', null, 'hello', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'da',
+          defaultLocale,
+          n: null,
+          singular: 'hello',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('hej')
     })
 
     it('translate a plural string', () => {
-      const output = getTranslation(
-        translationData,
-        'da',
-        3,
-        '{n} day',
-        '{n} days',
-        null,
-        opts
-      )
+      const output = getTranslation({
+        translations: translationData,
+        locale: 'da',
+        defaultLocale,
+        n: 3,
+        singular: '{n} day',
+        plural: '{n} days',
+        context: null,
+        options,
+      })
       const replaced = replaceString(output, { n: 3 })
       expect(replaced).toMatch('3 dage')
     })
 
     it('translates with fallback country code', () => {
       expect(
-        getTranslation(translationData, 'en', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'en',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('bye')
       expect(
-        getTranslation(translationData, 'da', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'da',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('farvel')
       expect(
-        getTranslation(translationData, 'da_DK', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'da_DK',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('farvel')
       expect(
-        getTranslation(translationData, 'da_GL', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'da_GL',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('farvel')
       expect(
-        getTranslation(
-          translationData,
-          'fr_FR',
-          null,
-          'hello',
-          null,
-          null,
-          opts
-        )
+        getTranslation({
+          translations: translationData,
+          locale: 'fr_FR',
+          defaultLocale,
+          n: null,
+          singular: 'hello',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('bonjour')
       expect(
-        getTranslation(translationData, 'fr_XX', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'fr_XX',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('au revoir')
       expect(
-        getTranslation(translationData, 'fr', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'fr',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('au revoir')
       expect(
-        getTranslation(translationData, 'de', null, 'bye', null, null, opts)
+        getTranslation({
+          translations: translationData,
+          locale: 'de',
+          defaultLocale,
+          n: null,
+          singular: 'bye',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('bye')
     })
 
@@ -116,24 +191,52 @@ describe('translate', () => {
       }
 
       expect(
-        getTranslation(set, 'test', null, 'a fish', null, null, opts)
+        getTranslation({
+          translations: set,
+          locale: 'test',
+          defaultLocale,
+          n: null,
+          singular: 'a fish',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('un poisson')
       expect(
-        getTranslation(
-          set,
-          'test_underscore',
-          null,
-          'a goldfish',
-          null,
-          null,
-          opts
-        )
+        getTranslation({
+          translations: set,
+          locale: 'test_underscore',
+          defaultLocale,
+          n: null,
+          singular: 'a goldfish',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('un poisson rouge')
       expect(
-        getTranslation(set, 'test-hyphen', null, 'a shark', null, null, opts)
+        getTranslation({
+          translations: set,
+          locale: 'test-hyphen',
+          defaultLocale,
+          n: null,
+          singular: 'a shark',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('un requin')
       expect(
-        getTranslation(set, 'test_undefined', null, 'test', null, null, opts)
+        getTranslation({
+          translations: set,
+          locale: 'test_undefined',
+          defaultLocale,
+          n: null,
+          singular: 'test',
+          plural: null,
+          context: null,
+          options,
+        })
       ).toMatch('test!')
     })
 
@@ -148,18 +251,42 @@ describe('translate', () => {
           '{n} user': ['{n} users', ['{n} 用户']],
         },
       }
-      expect(getTranslation(set, 'zh_TW', 0, '{n} user', '{n} users')).toMatch(
-        '{n} 用户'
-      )
-      expect(getTranslation(set, 'zh_TW', 1, '{n} user', '{n} users')).toMatch(
-        '{n} 用户'
-      )
-      expect(getTranslation(set, 'zh_TW', 2, '{n} user', '{n} users')).toMatch(
-        '{n} 用户'
-      )
+      expect(
+        getTranslation({
+          translations: set,
+          locale: 'zh_TW',
+          defaultLocale,
+          n: 0,
+          singular: '{n} user',
+          plural: '{n} users',
+          options,
+        })
+      ).toMatch('{n} 用户')
+      expect(
+        getTranslation({
+          translations: set,
+          locale: 'zh_TW',
+          defaultLocale,
+          n: 1,
+          singular: '{n} user',
+          plural: '{n} users',
+          options,
+        })
+      ).toMatch('{n} 用户')
+      expect(
+        getTranslation({
+          translations: set,
+          locale: 'zh_TW',
+          defaultLocale,
+          n: 2,
+          singular: '{n} user',
+          plural: '{n} users',
+          options,
+        })
+      ).toMatch('{n} 用户')
     })
 
-    it.only('falls back on default language', () => {
+    it('falls back on default language', () => {
       const set: Translations = {
         en_GB: {
           '': {
@@ -177,28 +304,63 @@ describe('translate', () => {
         },
       }
       expect(
-        getTranslation(set, 'en', null, 'hi', null, null, {
+        getTranslation({
+          translations: set,
+          locale: 'en',
           defaultLocale: 'en',
+          n: null,
+          singular: 'hi',
+          plural: null,
+          context: null,
+          options,
         })
       ).toMatch('hi')
       expect(
-        getTranslation(set, 'en_AU', null, 'hi', null, null, {
+        getTranslation({
+          translations: set,
+          locale: 'en_AU',
           defaultLocale: 'en',
+          n: null,
+          singular: 'hi',
+          plural: null,
+          context: null,
+          options,
         })
       ).toMatch('oi')
       expect(
-        getTranslation(set, 'en_GB', null, 'hi', null, null, {
+        getTranslation({
+          translations: set,
+          locale: 'en_GB',
           defaultLocale: 'en_AU',
+          n: null,
+          singular: 'hi',
+          plural: null,
+          context: null,
+          options,
         })
       ).toMatch('hai')
       expect(
-        getTranslation(set, 'en', null, 'hi', null, null, {
+        getTranslation({
+          translations: set,
+          locale: 'en',
           defaultLocale: 'en_AU',
+          n: null,
+          singular: 'hi',
+          plural: null,
+          context: null,
+          options,
         })
       ).toMatch('oi')
       expect(
-        getTranslation(set, 'invalid', null, 'hi', null, null, {
+        getTranslation({
+          translations: set,
+          locale: 'invalid',
           defaultLocale: 'en_AU',
+          n: null,
+          singular: 'hi',
+          plural: null,
+          context: null,
+          options,
         })
       ).toMatch('hi')
     })
@@ -206,20 +368,21 @@ describe('translate', () => {
 
   describe('fails on missing plural data', () => {
     beforeEach(() => {
-      jest.spyOn(console, 'warn').mockImplementation(() => opts)
+      jest.spyOn(console, 'warn').mockImplementation(() => options)
     })
 
     it('fail on a plural string', () => {
       const logSpy = jest.spyOn(console, 'warn')
-      getTranslation(
-        translationDataLowercase,
-        'da',
-        3,
-        '{n} day',
-        '{n} days',
-        null,
-        { verbose: true, defaultLocale: 'en' }
-      )
+      getTranslation({
+        translations: translationDataLowercase,
+        locale: 'da',
+        defaultLocale: 'en',
+        n: 3,
+        singular: '{n} day',
+        plural: '{n} days',
+        context: null,
+        options: { verbose: true },
+      })
       expect(logSpy).toHaveBeenCalledWith(
         'translations are missing Plural-Forms setting'
       )

--- a/src/translate/translate.tsx
+++ b/src/translate/translate.tsx
@@ -4,15 +4,27 @@ import { normalizeContent } from './normalize-content'
 
 const CONTEXT_GLUE = '\u0004'
 
-export const getTranslation = (
-  translations: Translations,
-  locale: string,
-  n: number | null,
-  singular: string,
-  plural?: string | null,
-  context?: string | null,
-  options: TranslationOptions = { defaultLocale: 'en' }
-): string => {
+interface GetTranslationOptions {
+  translations: Translations
+  locale: string
+  defaultLocale: string
+  n: number | null
+  singular: string
+  plural?: string | null
+  context?: string | null
+  options?: TranslationOptions
+}
+
+export const getTranslation = ({
+  translations,
+  locale,
+  defaultLocale,
+  n,
+  singular,
+  plural,
+  context,
+  options = {},
+}: GetTranslationOptions): string => {
   // Clean our translation.
   singular = normalizeContent(singular, options.content)
 
@@ -25,7 +37,7 @@ export const getTranslation = (
   const translationSet = getTranslationSetGracefully(
     translations,
     locale,
-    options.defaultLocale,
+    defaultLocale,
     msgid
   )
   const msgstr = (translationSet?.[msgid] || []).slice()

--- a/src/translate/translate.tsx
+++ b/src/translate/translate.tsx
@@ -125,6 +125,8 @@ const getTranslationSetGracefully = (
   if (exists(directMatch, msgid)) {
     return translations[directMatch]
   }
+  // If we have a direct with the `defaultLocale` but it wasn't found in the translation set
+  // then it means the source language is not being translated so return `null`.
   if (directMatch === defaultLocale) {
     return null
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface TranslationOptions {
   verbose?: boolean
   jsxWhitelist?: TranslateDataWithJSX
   replaceStringRegex?: ReplaceStringRegex
+  defaultLocale: string
 
   content?: {
     trimWhiteSpace?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface TranslationOptions {
   verbose?: boolean
   jsxWhitelist?: TranslateDataWithJSX
   replaceStringRegex?: ReplaceStringRegex
-  defaultLocale: string
 
   content?: {
     trimWhiteSpace?: boolean


### PR DESCRIPTION
This solves an issue where if the locale used is `en`, but you also have support for `en_AU` then it would fall back on `en_AU` since `en` would not be part of the translation set.